### PR TITLE
Update Google Analytics template in baseof.html

### DIFF
--- a/blog/themes/bilberry-hugo-theme/layouts/_default/baseof.html
+++ b/blog/themes/bilberry-hugo-theme/layouts/_default/baseof.html
@@ -117,7 +117,7 @@
 
     {{ partial "footer.html" . }}
 
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
 
     {{ if and (isset .Site.Params "enable_mathjax") (eq .Site.Params.enable_mathjax true) }}
     {{ partial "mathjax.html" . }}


### PR DESCRIPTION
This pull request includes a change to the `blog/themes/bilberry-hugo-theme/layouts/_default/baseof.html` file. The change updates the Google Analytics template being used.

* [`blog/themes/bilberry-hugo-theme/layouts/_default/baseof.html`](diffhunk://#diff-c4fdb302e4c851da3b42daff9dd63dd3b92f196cd4e541cffb5334ed3d2ba23aL120-R120): Replaced the `google_analytics_async.html` template with `google_analytics.html`.